### PR TITLE
Writeshuffler rework

### DIFF
--- a/fsresck/write.py
+++ b/fsresck/write.py
@@ -25,6 +25,24 @@
 """Handling of image modification requests (writes)."""
 
 
+def overlapping(iterator):
+    """Check if the writes in iterator are not overlapping each other."""
+    writes = list(iterator)
+
+    for i, write in enumerate(writes):
+        for other_write in writes[i+1:]:
+            write_start = write.lba
+            write_end = write.lba + len(write.data)
+            other_write_start = other_write.lba
+            other_write_end = other_write.lba + len(other_write.data)
+
+            if other_write_start < write_end < other_write_end:
+                return True
+            if other_write_start <= write_start < other_write_end:
+                return True
+    return False
+
+
 class Write(object):
 
     """Single image modification request."""

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -24,7 +24,7 @@ try:
 except ImportError:
         import unittest
 
-from fsresck.write import Write
+from fsresck.write import Write, overlapping
 
 class TestWrite(unittest.TestCase):
     def test___init__(self):
@@ -96,3 +96,36 @@ class TestWrite(unittest.TestCase):
 
         self.assertEqual(write.start_time, 12)
         self.assertEqual(write.end_time, 14)
+
+class TestOverlapping(unittest.TestCase):
+    def test_non_overlapping(self):
+        writes = [Write(lba=0, data=bytearray(512)),
+                  Write(lba=512, data=bytearray(512)),
+                  Write(lba=1024, data=bytearray(512))]
+
+        self.assertFalse(overlapping(writes))
+
+    def test_overlapping_second_beginning(self):
+        writes = [Write(lba=512, data=bytearray(512)),
+                  Write(lba=1023, data=bytearray(512))]
+
+        self.assertTrue(overlapping(writes))
+
+    def test_overlapping_second_end(self):
+        writes = [Write(lba=512, data=bytearray(512)),
+                  Write(lba=0, data=bytearray(513))]
+
+        self.assertTrue(overlapping(writes))
+
+    def test_overlapping_first_beginning(self):
+        writes = [Write(lba=1023, data=bytearray(512)),
+                  Write(lba=512, data=bytearray(512))]
+
+        self.assertTrue(overlapping(writes))
+
+    def test_overlapping_first_end(self):
+        writes = [Write(lba=0, data=bytearray(513)),
+                  Write(lba=512, data=bytearray(512))]
+
+        self.assertTrue(overlapping(writes))
+

--- a/tests/test_writesshuffler.py
+++ b/tests/test_writesshuffler.py
@@ -57,12 +57,16 @@ class TestWritesShuffler(unittest.TestCase):
 
         ws = WritesShuffler(image, writes)
         tests = list(ws.generator())
-        self.assertEqual(len(tests), 1)
+        self.assertEqual(len(tests), 2)
         self.assertEqual(len(tests[0]), 2)
         image, writes = tests[0]
         self.assertEqual(image.image_name, "/tmp/some-name")
         self.assertEqual(image.writes, [])
         self.assertEqual(writes, tuple())
+        image, writes = tests[1]
+        self.assertEqual(image.image_name, "/tmp/some-name")
+        self.assertEqual(image.writes, [])
+        self.assertEqual(writes, tuple([Write(lba=0, data=bytearray(512))]))
 
     def test_generator_with_invalid_data(self):
         ws = WritesShuffler(None, [])
@@ -79,48 +83,130 @@ class TestWritesShuffler(unittest.TestCase):
         image = Image("/dev/null", [])
         # mock the object to not create an image copy
         image.create_image = lambda x: "/tmp/some-name"
+        # writes need to overlap to create permutations instead of combinations
         writes = [
             Write(lba=0, data=bytearray(512)),
-            Write(lba=512, data=bytearray(512)),
-            Write(lba=1024, data=bytearray(512)),
+            Write(lba=1, data=bytearray(512)),
+            Write(lba=2, data=bytearray(512)),
+            Write(lba=3, data=bytearray(512))
             ]
 
         ws = WritesShuffler(image, writes)
 
         tests = list(ws.generator())
 
-        self.assertEqual(len(tests), 6)
+        self.assertEqual(len(tests), 22)
         self.assertEqual(len(tests[0]), 2)
 
         test_image, test_writes = tests[0]
         self.assertEqual(test_image.image_name, "/tmp/some-name")
-        self.assertEqual(test_image.writes, [writes[0], writes[1]])
+        self.assertEqual(test_image.writes, [])
         self.assertEqual(test_writes, tuple())
 
         test_image, test_writes = tests[1]
         self.assertEqual(test_image.image_name, "/tmp/some-name")
-        self.assertEqual(test_image.writes, [writes[0]])
-        self.assertEqual(test_writes, (writes[2], writes[1]))
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[0], ))
 
         test_image, test_writes = tests[2]
         self.assertEqual(test_image.image_name, "/tmp/some-name")
         self.assertEqual(test_image.writes, [])
-        self.assertEqual(test_writes, (writes[1], writes[0], writes[2]))
+        self.assertEqual(test_writes, (writes[1], ))
 
         test_image, test_writes = tests[3]
         self.assertEqual(test_image.image_name, "/tmp/some-name")
         self.assertEqual(test_image.writes, [])
-        self.assertEqual(test_writes, (writes[1], writes[2], writes[0]))
+        self.assertEqual(test_writes, (writes[2], ))
 
         test_image, test_writes = tests[4]
         self.assertEqual(test_image.image_name, "/tmp/some-name")
         self.assertEqual(test_image.writes, [])
-        self.assertEqual(test_writes, (writes[2], writes[0], writes[1]))
+        self.assertEqual(test_writes, (writes[0], writes[1]))
 
         test_image, test_writes = tests[5]
         self.assertEqual(test_image.image_name, "/tmp/some-name")
         self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[0], writes[2]))
+
+        test_image, test_writes = tests[6]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[1], writes[0]))
+
+        test_image, test_writes = tests[7]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[1], writes[2]))
+
+        test_image, test_writes = tests[8]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[2], writes[0]))
+
+        test_image, test_writes = tests[9]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[2], writes[1]))
+
+        test_image, test_writes = tests[10]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[0], writes[1], writes[2]))
+
+        test_image, test_writes = tests[11]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[0], writes[2], writes[1]))
+
+        test_image, test_writes = tests[12]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[1], writes[0], writes[2]))
+
+        test_image, test_writes = tests[13]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[1], writes[2], writes[0]))
+
+        test_image, test_writes = tests[14]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[2], writes[0], writes[1]))
+
+        test_image, test_writes = tests[15]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
         self.assertEqual(test_writes, (writes[2], writes[1], writes[0]))
+
+        test_image, test_writes = tests[16]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [writes[0]])
+        self.assertEqual(test_writes, (writes[1], writes[2], writes[3]))
+
+        test_image, test_writes = tests[17]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [writes[0]])
+        self.assertEqual(test_writes, (writes[1], writes[3], writes[2]))
+
+        test_image, test_writes = tests[18]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [writes[0]])
+        self.assertEqual(test_writes, (writes[2], writes[1], writes[3]))
+
+        test_image, test_writes = tests[19]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [writes[0]])
+        self.assertEqual(test_writes, (writes[2], writes[3], writes[1]))
+
+        test_image, test_writes = tests[20]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [writes[0]])
+        self.assertEqual(test_writes, (writes[3], writes[1], writes[2]))
+
+        test_image, test_writes = tests[21]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [writes[0]])
+        self.assertEqual(test_writes, (writes[3], writes[2], writes[1]))
 
     def test_cleanup(self):
         patcher = mock.patch.object(os,

--- a/tests/test_writesshuffler.py
+++ b/tests/test_writesshuffler.py
@@ -208,6 +208,106 @@ class TestWritesShuffler(unittest.TestCase):
         self.assertEqual(test_image.writes, [writes[0]])
         self.assertEqual(test_writes, (writes[3], writes[2], writes[1]))
 
+    def test_generator_with_non_overlapping_writes(self):
+        image = Image("/dev/null", [])
+        # mock the object to not create an image copy
+        image.create_image = lambda x: "/tmp/some-name"
+        writes = [
+            Write(lba=0, data=bytearray(512)),
+            Write(lba=512, data=bytearray(512)),
+            Write(lba=1024, data=bytearray(512)),
+            Write(lba=1536, data=bytearray(512))
+            ]
+
+        ws = WritesShuffler(image, writes)
+
+        tests = list(ws.generator())
+
+        # if the writes are non-overlapping we are expecting combinations
+        # not permutations
+        self.assertEqual(len(tests), 16)
+        self.assertEqual(len(tests[0]), 2)
+
+        test_image, test_writes = tests[0]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, tuple())
+
+        test_image, test_writes = tests[1]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[0], ))
+
+        test_image, test_writes = tests[2]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[1], ))
+
+        test_image, test_writes = tests[3]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[2], ))
+
+        test_image, test_writes = tests[4]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[3], ))
+
+        test_image, test_writes = tests[5]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[0], writes[1]))
+
+        test_image, test_writes = tests[6]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[0], writes[2]))
+
+        test_image, test_writes = tests[7]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[0], writes[3]))
+
+        test_image, test_writes = tests[8]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[1], writes[2]))
+
+        test_image, test_writes = tests[9]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[1], writes[3]))
+
+        test_image, test_writes = tests[10]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[2], writes[3]))
+
+        test_image, test_writes = tests[11]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[0], writes[1], writes[2]))
+
+        test_image, test_writes = tests[12]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[0], writes[1], writes[3]))
+
+        test_image, test_writes = tests[13]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[0], writes[2], writes[3]))
+
+        test_image, test_writes = tests[14]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [])
+        self.assertEqual(test_writes, (writes[1], writes[2], writes[3]))
+
+        test_image, test_writes = tests[15]
+        self.assertEqual(test_image.image_name, "/tmp/some-name")
+        self.assertEqual(test_image.writes, [writes[0]])
+        self.assertEqual(test_writes, (writes[1], writes[2], writes[3]))
+
     def test_cleanup(self):
         patcher = mock.patch.object(os,
                                     'unlink',


### PR DESCRIPTION
Rework writeshuffler to use iterators and generate sensible images irrespective of writes
