### PR TITLE
fix writeshuffler to return all permutations

### DIFF
--- a/fsresck/write.py
+++ b/fsresck/write.py
@@ -63,6 +63,11 @@ class Write(object):
         self.start_time = None
         self.end_time = None
 
+    def __hash__(self):
+        """Return the hash of the object."""
+        return hash((self.offset, bytes(self.data), self.disk_id,
+                     self.start_time, self.end_time))
+
     def __repr__(self):
         """Return human-readable representation of the object."""
         if self.disk_id is None and self.start_time is None and \


### PR DESCRIPTION
for writes like 0, 1, 2, 3 where all overlap, some permutations
were not returned, like all of them in order, or 0, 3, 1

at the same time, for writes not overlapping, do draw
from the same sized set as for permutations not a larger set

Test also uniqueness of all the generated images for larger sets of
writes