### PR TITLE
more precise time

### DIFF
--- a/fsresck/imagegenerator.py
+++ b/fsresck/imagegenerator.py
@@ -40,20 +40,20 @@ class LogHeader(object):
 
     Reads the following fields in big-endian format:
     32bit unsigned int - operation type (only "1" supported - write),
-    double precision floating point number - start time in seconds from epoch,
-    double precision floating point number - end time in seconds from epoch,
+    64bit unsigned int - start time in nanoseconds from epoch,
+    64bit unsigned int - end time in nanoseconds from epoch,
     64bit unsigned integer - disk offset in bytes
     32bit unsigned integer - length of data payload
     """
 
-    header_format = '!IddQi'
+    header_format = '!IQQQi'
     header_length = struct.calcsize(header_format)
 
     def __init__(self):
         """Create object."""
         self.operation = 0
-        self.start_time = 0.0
-        self.end_time = 0.0
+        self.start_time = 0
+        self.end_time = 0
         self.offset = 0
         self.length = 0
 

--- a/tests/nbd/test_request.py
+++ b/tests/nbd/test_request.py
@@ -47,7 +47,7 @@ class TestError(unittest.TestCase):
         with self.assertRaises(Error) as exception:
             raise Error('test')
 
-        self.assertEqual(repr(exception.exception), "request.Error('test',)")
+        self.assertIn("request.Error('test'", repr(exception.exception))
 
 
 class TestNBDRequest(unittest.TestCase):


### PR DESCRIPTION
don't use time format that will be less precise than the clock source in just few decades

also make the tests pass on py3.7